### PR TITLE
Added example patch for skipping the intro FMV

### DIFF
--- a/MonsterTrainModdingAPI/Patches/SkipIntroFMVPatch.cs
+++ b/MonsterTrainModdingAPI/Patches/SkipIntroFMVPatch.cs
@@ -3,7 +3,7 @@
 namespace MonsterTrainModdingAPI.Patches
 {
     [HarmonyPatch(typeof(IntroFmvScreen), "Initialize")]
-    class IntroFmvScreen_Initialize_Patch
+    class SkipIntroFMVPatch
     {
         static bool Prefix(ref IntroFmvScreen __instance)
         {

--- a/MonsterTrainModdingAPI/Patches/SkipIntroFMVPatch.cs
+++ b/MonsterTrainModdingAPI/Patches/SkipIntroFMVPatch.cs
@@ -1,0 +1,14 @@
+﻿using HarmonyLib;
+
+namespace MonsterTrainModdingAPI.Patches
+{
+    [HarmonyPatch(typeof(IntroFmvScreen), "Initialize")]
+    class IntroFmvScreen_Initialize_Patch
+    {
+        static bool Prefix(ref IntroFmvScreen __instance)
+        {
+            __instance.Invoke("GoToNextScreen", 0);
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Seems like a common request and is a quick and easy patch.

GoToNextScreen would usually get called when the MediaPlayer fires the "FinishedPlaying" event. Instead we call it right away and skip the player doing anything.

Includes invoking a method (without parameters) of an instance provided by Harmony, which hasn't been used in any of the example patches.