### PR TITLE
Set asset name of custom card data to the card's ID

### DIFF
--- a/MonsterTrainModdingAPI/Builders/CardDataBuilder.cs
+++ b/MonsterTrainModdingAPI/Builders/CardDataBuilder.cs
@@ -235,6 +235,7 @@ namespace MonsterTrainModdingAPI.Builders
             this.LinkedClass = CustomCardManager.SaveManager.GetAllGameData().FindClassData(this.ClanID);
             CardData cardData = ScriptableObject.CreateInstance<CardData>();
             AccessTools.Field(typeof(CardData), "id").SetValue(cardData, this.CardID);
+            cardData.name = this.CardID;
             if (this.CardArtPrefabVariantRef == null)
             {
                 this.CreateAndSetCardArtPrefabVariantRef(this.AssetPath, this.AssetPath);


### PR DESCRIPTION
This fixes the issue where the player is not charged for purchases made involving custom cards.